### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,30 +11,30 @@ Adafruit_NeoPixel	KEYWORD1
 #######################################	
 
 setPixelColor	KEYWORD2
-setPin			KEYWORD2
+setPin	KEYWORD2
 setBrightness	KEYWORD2
-numPixels		KEYWORD2
+numPixels	KEYWORD2
 getPixelColor	KEYWORD2
-Color			KEYWORD2
-show			KEYWORD2
+Color	KEYWORD2
+show	KEYWORD2
 
-clear			KEYWORD2
-updateLength			KEYWORD2
-updateType			KEYWORD2
-getPixels			KEYWORD2
-getBrightness			KEYWORD2
-getPin			KEYWORD2
-canShow			KEYWORD2
+clear	KEYWORD2
+updateLength	KEYWORD2
+updateType	KEYWORD2
+getPixels	KEYWORD2
+getBrightness	KEYWORD2
+getPin	KEYWORD2
+canShow	KEYWORD2
 
 
 #######################################
 # Constants
 #######################################
 
-NEO_COLMASK		LITERAL1
-NEO_SPDMASK		LITERAL1
-NEO_KHZ800		LITERAL1
-NEO_KHZ400		LITERAL1
-NEO_GRB			LITERAL1
-NEO_RGB			LITERAL1
-NEO_RGBW			LITERAL1
+NEO_COLMASK	LITERAL1
+NEO_SPDMASK	LITERAL1
+NEO_KHZ800	LITERAL1
+NEO_KHZ400	LITERAL1
+NEO_GRB	LITERAL1
+NEO_RGB	LITERAL1
+NEO_RGBW	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords